### PR TITLE
bugfix download btn & showing error message on unsuccessful setting email 

### DIFF
--- a/src/components/Account/MainLayout.js
+++ b/src/components/Account/MainLayout.js
@@ -29,26 +29,14 @@ const useStyles = createStyles((theme) => ({
 
 const AccountMainLayout = ({ pageName, children, pageTitle, description }) => {
   const { user } = useMoralis();
-  const [email, setEmail] = useState(null);
   const { classes } = useStyles();
-  const getEmail = useCallback(() => {
-    if (user?.attributes?.email) {
-      setEmail(user.attributes.email);
-    }
-  }, [user]);
-
-  useEffect(() => {
-    if (!email) {
-      getEmail();
-    }
-  }, [email, getEmail]);
   return (
     <Layout withAuth pageTitle={pageTitle} description={description}>
       <Flex className={classes.container} direction='row'>
         <Flex className={classes.accountOverviewBoxContainer}>
           <AccountOverviewBox
             pageName={pageName ?? pageTitle}
-            email={email}
+            email={user?.attributes?.email}
             ethAddress={user?.attributes?.ethAddress}
           />
         </Flex>

--- a/src/components/Form/AuthForm.js
+++ b/src/components/Form/AuthForm.js
@@ -20,6 +20,7 @@ const AuthForm = ({ forLogin = false }) => {
     login,
     isAuthenticating,
     authError,
+    userError,
   } = useMoralis();
   const hasEmail = user?.attributes?.email;
 
@@ -129,12 +130,6 @@ const AuthForm = ({ forLogin = false }) => {
           {...form.getInputProps('password')}
         />
 
-        {!!authError && forLogin && (
-          <Text sx={{ color: '#ca4242' }} mt='md'>
-            {moralisErrorMessage('auth', authError.code)}
-          </Text>
-        )}
-
         <Button
           h='48px'
           miw='200px'
@@ -162,6 +157,18 @@ const AuthForm = ({ forLogin = false }) => {
             </Text>
           )}
         </Button>
+
+        {!!authError && forLogin && (
+          <Text sx={{ color: '#ca4242' }} mt='md'>
+            {moralisErrorMessage('auth', authError.code)}
+          </Text>
+        )}
+
+        {!!userError && (
+          <Text sx={{ color: '#ca4242' }} mt='md'>
+            {userError.message}
+          </Text>
+        )}
       </form>
     </>
   );

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -79,7 +79,6 @@ const Layout = ({
             },
           }}
           pos='relative'
-          margi
           h={'calc(100vh - 80px)'}
         >
           <Container

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -28,7 +28,7 @@ const useStyles = createStyles((theme) => ({
 
 export default function Home() {
   const { isAuthenticated, user } = useMoralis();
-  const emailConnected = !!(user && user.get('emailAddress'));
+  const emailConnected = !!(user && user.get('email'));
   // checks if the user has AT LEAST 1 key of salvation
   const [hasKey, setHasKey] = useState(false);
   const { classes } = useStyles();


### PR DESCRIPTION
Bugfix download btn & showing error message on unsuccessful setting email. Previously, when email has been used by other user, the request fails and no error msg shows up. This gives the impression that the setting of email and password didn't work. With this PR, error message shows properly, thus users can see if it fails because of any reason.